### PR TITLE
Updated POST endpoints ISSUE#28

### DIFF
--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -16,15 +16,16 @@ router.use('/', async (req, res, next) => {
 });
 
 /* User creates/updates a specific tag/interaction. */
-router.post('/:name', async (req, res) => {
-  const tag_name = req.params.name;
-  const interaction = req.query.interaction;
-  let value = req.query.value;
+router.post('/', async (req, res) => {
+  const tag_name = req.body.name;
+  const interaction = req.body.interaction;
+  const value = req.body.value;
   if (!value) value = '';
   const token_id = res.locals.token_id;
   console.log(token_id);
   try {
-    var query = `INSERT IGNORE INTO tags (token_id, name, value, created) VALUES (${token_id}, '${tag_name}', '${value}', CURRENT_TIMESTAMP());`;
+    var query = `INSERT INTO tags (token_id, name, value, created) VALUES (${token_id}, '${tag_name}', '${value}', CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE value='${value}';`
+    //var query = `INSERT IGNORE INTO tags (token_id, name, value, created) VALUES (${token_id}, '${tag_name}', '${value}', CURRENT_TIMESTAMP());`;
     var results = await executeQuery(query);
     var tag_id = results.insertId;
     /* Tag already exist so we need to obtain its 'id' to enter the new interaction. */

--- a/server/routes/tokens.js
+++ b/server/routes/tokens.js
@@ -33,7 +33,7 @@ router.get('/', async (req, res) => {
 
 /* Create a token. */
 router.post('/', async (req, res) => {
-  const organization = req.query.interaction;
+  const organization = req.body.organization;
   /* Checks and handles if the organization making the post request already has an existing token/account with us. */
   const org_token = await check_organizational_existance(organization);
   if (org_token) {


### PR DESCRIPTION
I updated POST endpoints to use `req.body` instead of `req.params`. These updates have been updated in the readme file. Additionally, I changed the POST 'api/tags/' endpoint to update the value column of the tag if the tag already exists in the DB.